### PR TITLE
fix: handle ping method in MCP protocol

### DIFF
--- a/Sources/simplebanking-mcp/MCPProtocol.swift
+++ b/Sources/simplebanking-mcp/MCPProtocol.swift
@@ -119,6 +119,8 @@ func handleMessage(_ msg: [String: Any]) -> [String: Any]? {
             "content": [["type": "text", "text": text]],
             "isError": isError
         ])
+    case "ping":
+        return response(id: id, result: [String: Any]())
     default:
         return errorResponse(id: id, code: -32601, message: "Method not found: \(method)")
     }


### PR DESCRIPTION
The MCP SDK used by AnythingLLM sends a ping request after the initialize handshake to verify the server is still alive. The missing handler caused a -32601 Method not found error, which AnythingLLM treated as fatal, closing the connection immediately.

Added ping as a no-op returning an empty result object, per the MCP specification.

Fixes compatibility with AnythingLLM and any other MCP client that uses ping for keepalive checks.